### PR TITLE
use nats port from env if possible and default to expected nats port 4222

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2,6 +2,7 @@ version: "3"
 
 env:
   STATIC_DIR: "web/static"
+  NATS_PORT: 4222
 
 tasks:
   # The `build:` tasks below are used together for "production" builds of your project


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message is descriptive
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Tries to use the nats default port of 4222 (or whatever was specified in your NATS_PORT env variable) and if not possible then uses a free random port


* **What is the current behavior?** (You can also link to an open issue here)
Currently uses a free random port


* **What is the new behavior (if this is a feature change)?**
Being able to specify what port the nats server is running on. - No change in behaviour
Now the CLI will work e.g. "nats kv ls" will correctly print out the key value store without having to grab the port number from nats and do something like this: "nats kv ls -s nats://localhost:513943"


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**: