### PR TITLE
fix: update build container version to go1.24.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.23.3-alpine AS build
+FROM docker.io/golang:1.24.0-alpine AS build
 
 RUN apk add --no-cache upx
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] The commit message is descriptive
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix, docker image won't build because go.mod requires go1.24.0


* **What is the current behavior?** (You can also link to an open issue here)
Docker image won't build 
` > [build 5/7] RUN go mod download:                                                                                                               
0.186 go: go.mod requires go >= 1.24.0 (running go 1.23.3; GOTOOLCHAIN=local)
------`

* **What is the new behavior (if this is a feature change)?**
docker image builds fine



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no


* **Other information**: