### PR TITLE
Bump Dockerfile Go image from 1.24.0 -> 1.24.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/golang:1.24.0-alpine AS build
+FROM docker.io/golang:1.24.2-alpine AS build
 
 RUN apk add --no-cache upx
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message is descriptive
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Fixes an error when running `docker build -t northstar:latest .`

* **What is the current behavior?** (You can also link to an open issue here)

```
=> ERROR [build 5/7] RUN go mod download
0.4s
------
 > [build 5/7] RUN go mod download:
0.339 go: go.mod requires go >= 1.24.2 (running go 1.24.0; GOTOOLCHAIN=local)
------
```

* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**: