### PR TITLE
Fix downloader command path in Taskfile

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -48,7 +48,7 @@ tasks:
   # Use this task to download latest version of client libs
   download:
     cmds:
-      - go run cmd/downloader/main.go
+      - go run cmd/web/downloader/main.go
 
   # The `live:` tasks below are used together for development builds and will live-reload the server
   live:templ:


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message is descriptive
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix


* **What is the current behavior?** (You can also link to an open issue here)
The `download` command in the Taskfile had the wrong path to the `downloader/main.go` file. It runs `cmd/downloader/main.go`


* **What is the new behavior (if this is a feature change)?**
The `download` command now works as intented. It now runs `cmd/web/downloader/main.go`.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Don't think so, unless there's a broken pipeline that dependended on this Taskfile somewhere.


* **Other information**: