### PR TITLE
feat(theme): implement light/dark mode with persistent storage

### DIFF
--- a/cmd/web/build/main.go
+++ b/cmd/web/build/main.go
@@ -44,6 +44,14 @@ func build(ctx context.Context) error {
 				InputPath:  resources.LibsDirectoryPath + "/web-components/reverse-component/index.ts",
 				OutputPath: "libs/reverse-component",
 			},
+			{
+				InputPath:  resources.LibsDirectoryPath + "/web-components/theme-controller/theme-controller.ts",
+				OutputPath: "libs/theme-controller",
+			},
+			{
+				InputPath:  resources.LibsDirectoryPath + "/web-components/theme-controller/theme-bootstrap.ts",
+				OutputPath: "libs/theme-bootstrap",
+			},
 			/*
 				uncomment the entrypoint below after running pnpm install in the resources.LibsDirectoryPath + /lit directory
 				esbuild will only be able to find the lit + sortable libraries after doing so

--- a/features/common/layouts/base.templ
+++ b/features/common/layouts/base.templ
@@ -18,12 +18,35 @@ templ Base(title string) {
 			<link rel="icon" type="image/x-icon" href={ resources.StaticPath("assets/favicon.ico") }/>
 			<script defer type="module" src={ resources.StaticPath("datastar/datastar.js") }></script>
 			<link href={ resources.StaticPath("index.css") } rel="stylesheet" type="text/css"/>
+		    <script src={ resources.StaticPath("libs/theme-bootstrap.js") }></script>
 		</head>
-		<body class="flex flex-col h-screen">
+		<body class="flex flex-col min-h-screen">
 			if config.Global.Environment == config.Dev {
 				<div data-init="@get('/reload', {retryMaxCount: Infinity, retryInterval:20, retryMaxWaitMs:200})"></div>
 			}
-			{ children... }
+
+			<!-- Theme switcher (uses web/libs/web-components/theme-controller -> built to web/resources/static/libs/theme-controller.js) -->
+			<div class="relative w-full">
+				<div class="mx-auto max-w-5xl">
+                	{ children... }
+				</div>
+
+                <div class="absolute top-3 right-3">
+                    <button
+                        type="button"
+                        class="btn btn-sm btn-circle"
+                        aria-label="Change the theme"
+                        onclick="window.themeController?.toggleTheme()"
+                    >
+                        <iconify-icon
+                            icon="mdi:theme-light-dark"
+                            width="20"
+                            height="20"
+                        ></iconify-icon>
+                    </button>
+                </div>
+            </div>
+			<script type="module" defer src={ resources.StaticPath("libs/theme-controller.js") }></script>
 		</body>
 	</html>
 }

--- a/features/common/layouts/base_templ.go
+++ b/features/common/layouts/base_templ.go
@@ -86,21 +86,51 @@ func Base(title string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\" rel=\"stylesheet\" type=\"text/css\"></head><body class=\"flex flex-col h-screen\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "\" rel=\"stylesheet\" type=\"text/css\"><script src=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var6 string
+		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.ResolveAttributeValue(resources.StaticPath("libs/theme-bootstrap.js"))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `features/common/layouts/base.templ`, Line: 21, Col: 67}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var6)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "\"></script></head><body class=\"flex flex-col min-h-screen\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if config.Global.Environment == config.Dev {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<div data-init=\"@get('/reload', {retryMaxCount: Infinity, retryInterval:20, retryMaxWaitMs:200})\"></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "<div data-init=\"@get('/reload', {retryMaxCount: Infinity, retryInterval:20, retryMaxWaitMs:200})\"></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<!-- Theme switcher (uses web/libs/web-components/theme-controller -> built to web/resources/static/libs/theme-controller.js) --><div class=\"relative w-full\"><div class=\"mx-auto max-w-5xl\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
 		}
 		templ_7745c5c3_Err = templ_7745c5c3_Var1.Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "</body></html>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</div><div class=\"absolute top-3 right-3\"><button type=\"button\" class=\"btn btn-sm btn-circle\" aria-label=\"Change the theme\" onclick=\"window.themeController?.toggleTheme()\"><iconify-icon icon=\"mdi:theme-light-dark\" width=\"20\" height=\"20\"></iconify-icon></button></div></div><script type=\"module\" defer src=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var7 string
+		templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.ResolveAttributeValue(resources.StaticPath("libs/theme-controller.js"))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `features/common/layouts/base.templ`, Line: 49, Col: 85}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ_7745c5c3_Var7)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "\"></script></body></html>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/features/counter/pages/counter.templ
+++ b/features/counter/pages/counter.templ
@@ -55,7 +55,7 @@ templ Counter(signals CounterSignals) {
 templ CounterPage() {
 	@layouts.Base("Counter") {
 		@components.Navigation(components.PageCounter)
-		<article class="prose mx-auto m-2">
+		<article class="prose mx-auto mt-5">
 			<div id="container" data-init={ datastar.GetSSE("/counter/data") }></div>
 		</article>
 	}

--- a/features/counter/pages/counter_templ.go
+++ b/features/counter/pages/counter_templ.go
@@ -194,7 +194,7 @@ func CounterPage() templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, " <article class=\"prose mx-auto m-2\"><div id=\"container\" data-init=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, " <article class=\"prose mx-auto mt-5\"><div id=\"container\" data-init=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/features/index/components/todo.templ
+++ b/features/index/components/todo.templ
@@ -44,7 +44,7 @@ templ TodosMVCView(mvc *TodoMVC) {
 			input = mvc.Todos[mvc.EditingIdx].Text
 		}
 	}}
-	<div id="todos-container" class="h-full relative border border-solid border-primary rounded p-2 my-2 mx-28">
+	<div id="todos-container" class="h-full relative border border-solid border-primary rounded p-2 mt-5 mx-28">
 		<div
 			class="flex flex-col w-full gap-4"
 			data-signals={ fmt.Sprintf("{input:'%s'}", input) }

--- a/features/index/components/todo_templ.go
+++ b/features/index/components/todo_templ.go
@@ -70,7 +70,7 @@ func TodosMVCView(mvc *TodoMVC) templ.Component {
 		if mvc.EditingIdx >= 0 {
 			input = mvc.Todos[mvc.EditingIdx].Text
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div id=\"todos-container\" class=\"h-full relative border border-solid border-primary rounded p-2 my-2 mx-28\"><div class=\"flex flex-col w-full gap-4\" data-signals=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, "<div id=\"todos-container\" class=\"h-full relative border border-solid border-primary rounded p-2 mt-5 mx-28\"><div class=\"flex flex-col w-full gap-4\" data-signals=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/features/sortable/pages/sortable.templ
+++ b/features/sortable/pages/sortable.templ
@@ -9,8 +9,8 @@ import (
 templ SortablePage() {
 	@layouts.Base("Sortable") {
 		@components.Navigation(components.PageSortable)
-		<article class="prose mx-auto pt-2 flex flex-col gap-2">
-			<div class="alert alert-warning text-center">
+		<article class="prose mx-auto pt-2 flex flex-col gap-2 mt-5">
+			<div class="alert alert-warning text-center max-w-3xl mx-auto">
 				@components.Icon("material-symbols:warning")
 				<div class="flex flex-col gap-2">
 					<span>This example uses <a class="link" href="https://lit.dev/">lit</a> and <a class="link" href="https://github.com/SortableJS/Sortable">SortableJS</a>, you will need to download both libraries before this example will work</span>

--- a/features/sortable/pages/sortable_templ.go
+++ b/features/sortable/pages/sortable_templ.go
@@ -51,7 +51,7 @@ func SortablePage() templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, " <article class=\"prose mx-auto pt-2 flex flex-col gap-2\"><div class=\"alert alert-warning text-center\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 1, " <article class=\"prose mx-auto pt-2 flex flex-col gap-2 mt-5\"><div class=\"alert alert-warning text-center max-w-3xl mx-auto\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}

--- a/web/libs/web-components/theme-controller/theme-bootstrap.ts
+++ b/web/libs/web-components/theme-controller/theme-bootstrap.ts
@@ -1,0 +1,13 @@
+// Minimal bootstrap code to apply the user's saved theme before the page renders, preventing a flash of the wrong theme.
+const THEME_KEY = "site-theme";
+
+const saved = localStorage.getItem(THEME_KEY);
+
+const theme =
+  saved === "light" || saved === "dark"
+    ? saved
+    : window.matchMedia("(prefers-color-scheme: dark)").matches
+      ? "dark"
+      : "light";
+
+document.documentElement.setAttribute("data-theme", theme);

--- a/web/libs/web-components/theme-controller/theme-controller.ts
+++ b/web/libs/web-components/theme-controller/theme-controller.ts
@@ -1,0 +1,91 @@
+const THEME_KEY = "site-theme";
+
+export type Theme = "light" | "dark";
+
+export function applyTheme(theme: Theme): void {
+  document.documentElement.setAttribute("data-theme", theme);
+}
+
+export function saveTheme(theme: Theme): void {
+  localStorage.setItem(THEME_KEY, theme);
+}
+
+export function loadTheme(): Theme | null {
+  const theme = localStorage.getItem(THEME_KEY);
+
+  if (theme === "light" || theme === "dark") {
+    return theme;
+  }
+
+  return null;
+}
+
+export function getSystemTheme(): Theme {
+  return window.matchMedia("(prefers-color-scheme: light)").matches
+    ? "dark"
+    : "light";
+}
+
+export function initTheme(): Theme {
+  const savedTheme = loadTheme();
+
+  const theme = savedTheme ?? getSystemTheme();
+
+  applyTheme(theme);
+
+  return theme;
+}
+
+export function getTheme(): Theme {
+    const theme = document.documentElement.getAttribute("data-theme");
+
+    if (theme === "light" || theme === "dark") {
+        return theme;
+    }
+
+    return getSystemTheme();
+}
+
+export function setTheme(theme: Theme): void {
+  applyTheme(theme);
+  saveTheme(theme);
+}
+
+export function toggleTheme(): Theme {
+  const currentTheme = getTheme();
+
+  const nextTheme: Theme = currentTheme === "dark" ? "light" : "dark";
+
+  setTheme(nextTheme);
+
+  return nextTheme;
+}
+
+declare global {
+  interface Window {
+    themeController?: {
+      getTheme: () => Theme;
+      setTheme: (theme: Theme) => void;
+      toggleTheme: () => Theme;
+    };
+  }
+}
+
+if (typeof window !== "undefined") {
+    const initialTheme = initTheme();
+
+    window.themeController = {
+        getTheme,
+        setTheme,
+        toggleTheme,
+    };
+
+    window.dispatchEvent(
+        new CustomEvent("theme-ready", {
+            detail: {
+                theme: initialTheme,
+            },
+        }),
+    );
+}
+

--- a/web/resources/styles/styles.css
+++ b/web/resources/styles/styles.css
@@ -7,23 +7,47 @@
 */
 
 @plugin "./daisyui/daisyui.js" {
-    themes: light --default, dark --prefersdark;
+  themes:
+    light --default,
+    dark --prefersdark;
 }
 
 @plugin "./daisyui/daisyui-theme.js" {
-    name: "datastar";
+  name: "light";
 
-    --color-base-100: "#0b1325";
-    --color-base-200: "#1e304a";
-    --color-base-300: "#3a506b";
-    --color-primary: "#c9a75f";
-    --color-secondary: "#bfdbfe";
-    --color-accent: "#7dd3fc";
-    --color-neutral: "#444";
-    --color-neutral-content: "#fff";
-    --color-info: "#0369a1";
-    --color-success: "#69c383";
-    --color-warning: "#facc15";
-    --color-error: "#e11d48";
-  
+  --color-base-100: "#f8fafc";
+  --color-base-200: "#DBDBDB";
+  --color-base-300: "#e2e8f0";
+
+  --color-primary: "#3f6f9f";
+  --color-secondary: "#64748b";
+  --color-accent: "#4f91b8";
+
+  --color-neutral: "#334155";
+  --color-neutral-content: "#f8fafc";
+
+  --color-info: "#4f91b8";
+  --color-success: "#4f9d78";
+  --color-warning: "#b88932";
+  --color-error: "#c45c63";
+}
+
+@plugin "./daisyui/daisyui-theme.js" {
+  name: "dark";
+
+  --color-base-100: "#080c14";
+  --color-base-200: "#0d131f";
+  --color-base-300: "#151d2b";
+
+  --color-primary: "#4b83c4";
+  --color-secondary: "#64748b";
+  --color-accent: "#4f91b8";
+
+  --color-neutral: "#252f3f";
+  --color-neutral-content: "#cbd5e1";
+
+  --color-info: "#4f91b8";
+  --color-success: "#4f9d78";
+  --color-warning: "#c49a4a";
+  --color-error: "#c45c63";
 }


### PR DESCRIPTION
Tasks
- Add theme-controller web component for managing theme state
- Add theme-bootstrap to prevent flash of wrong theme on page load
- Configure build pipeline to compile theme controller TypeScript files
- Update DaisyUI theme configuration with custom light/dark color palettes
- Add theme toggle button to layout header with iconify-icon
- Improve layout spacing: change h-screen to min-h-screen for better flexibility
- Adjust component margins (mt-5) for consistent vertical spacing
- Update layout to use max-w-5xl container with relative positioning

Features:
- Persists user theme preference in localStorage
- Respects system color scheme preference as fallback
- No flash of incorrect theme (FOUC) due to bootstrap script
- Clean light and dark color schemes with custom palettes
- Accessible theme toggle button with aria-label

* **Please check if the PR fulfills these requirements**
- [x] The commit message is descriptive.
- [ ] Tests have been added for the changes (for bug fixes/new features).
- [ ] Documentation has been added/updated (for bug fixes/new features).

### What type of change does this pull request introduce?

New feature: adds a theme switcher for light and dark mode.

### What is the current behavior?

There was no option to switch between light and dark mode.

### What is the new behavior?

Users can now switch between light and dark mode using the theme switcher.

### Does this pull request introduce a breaking change?

No.

### Other information:

This adds a simple theme switcher to allow users to change the application's appearance between light and dark mode.

<img width="2843" height="1347" alt="image" src="https://github.com/user-attachments/assets/c40d1a10-14bc-484c-b598-c987d87509dd" />
<img width="2839" height="1338" alt="image" src="https://github.com/user-attachments/assets/3a54e705-aa10-4407-87fe-e017bd8c362f" />

Close #31 
